### PR TITLE
Move agent_id logging to top-level logger, add interface assertions, use errgroup.Go, document writerLoop

### DIFF
--- a/cmd/retina-agent/main.go
+++ b/cmd/retina-agent/main.go
@@ -98,6 +98,7 @@ func main() {
 	flag.Parse()
 
 	logger := newLogger(*logLevel)
+	logger = logger.With(slog.String("agent_id", *agentID))
 
 	cfg := &agent.Config{
 		AgentID:                    *agentID,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -269,9 +269,6 @@ func (a *agent) processorLoop(ctx context.Context, pds <-chan *api.ProbingDirect
 	}
 }
 
-// writerLoop encodes and sends ForwardingInfoElement messages to the orchestrator.
-// It reads from the fies channel, applies write deadlines, and handles encoding
-// errors. Returns when context is cancelled or fies channel is closed.
 func (a *agent) writerLoop(ctx context.Context, conn net.Conn, fies <-chan *api.ForwardingInfoElement) error {
 	encoder := json.NewEncoder(conn)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -271,6 +271,9 @@ func (a *agent) processorLoop(ctx context.Context, pds <-chan *api.ProbingDirect
 	}
 }
 
+// writerLoop encodes and sends ForwardingInfoElement messages to the orchestrator.
+// It reads from the fies channel, applies write deadlines, and handles encoding
+// errors. Returns when context is cancelled or fies channel is closed.
 func (a *agent) writerLoop(ctx context.Context, conn net.Conn, fies <-chan *api.ForwardingInfoElement) error {
 	encoder := json.NewEncoder(conn)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -262,11 +262,9 @@ func (a *agent) processorLoop(ctx context.Context, pds <-chan *api.ProbingDirect
 			}
 			a.metrics.ChannelDepth.WithLabelValues("pds").Set(float64(len(pds)))
 			a.metrics.PDGoroutines.Inc()
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				a.processPD(ctx, pd, fies)
-			}()
+			})
 		}
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -72,7 +72,7 @@ func Run(ctx context.Context, cfg *Config, logger *slog.Logger, metrics *Metrics
 	a := &agent{
 		config:  cfg,
 		prober:  prober,
-		logger:  logger.With(slog.String("agent_id", cfg.AgentID)),
+		logger:  logger,
 		metrics: metrics,
 	}
 

--- a/internal/agent/caracal_prober.go
+++ b/internal/agent/caracal_prober.go
@@ -57,6 +57,8 @@ type caracalProber struct {
 	g       *errgroup.Group
 }
 
+var _ (Prober) = (*caracalProber)(nil)
+
 // probeKey uniquely identifies a probe within a time window.
 type probeKey struct {
 	dstAddr           string

--- a/internal/agent/mock_prober.go
+++ b/internal/agent/mock_prober.go
@@ -21,6 +21,8 @@ type MockProber struct {
 	config *Config
 }
 
+var _ (Prober) = (*MockProber)(nil)
+
 func NewMockProber(cfg *Config) *MockProber {
 	return &MockProber{
 		rng:    rand.New(rand.NewSource(time.Now().UnixNano())), // #nosec G404 -- crypto/rand not needed for mock prober testing


### PR DESCRIPTION
## Changes

- Move `agent_id` slog field from agent-level logger to top-level logger in `main.go`
- Remove redundant `logger.With(agent_id)` from `agent.go`
- Replace `wg.Add(1)/go func()/defer wg.Done()` pattern with `wg.Go()`
- Add interface compliance assertions `var _ Prober = (*caracalProber)(nil)` and `var _ Prober = (*MockProber)(nil)`
- Add doc comment to `writerLoop`