### PR TITLE
fix(agent): improve pipeline observability and goroutine management

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -268,11 +268,9 @@ func (a *agent) processorLoop(ctx context.Context, pds <-chan *api.ProbingDirect
 			a.pdsDepth.Add(-1)
 			a.metrics.ChannelDepth.WithLabelValues("pds").Set(float64(a.pdsDepth.Load()))
 			a.metrics.PDGoroutines.Inc()
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				a.processPD(ctx, pd, fies)
-			}()
+			})
 		}
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -32,6 +32,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -46,6 +47,9 @@ type agent struct {
 	prober  Prober
 	logger  *slog.Logger
 	metrics *Metrics
+
+	pdsDepth  atomic.Int64
+	fiesDepth atomic.Int64
 }
 
 type probeResult struct {
@@ -197,7 +201,8 @@ func (a *agent) readerLoop(ctx context.Context, conn net.Conn, pds chan<- *api.P
 		case <-ctx.Done():
 			return ctx.Err()
 		case pds <- &pd:
-			a.metrics.ChannelDepth.WithLabelValues("pds").Set(float64(len(pds)))
+			a.pdsDepth.Add(1)
+			a.metrics.ChannelDepth.WithLabelValues("pds").Set(float64(a.pdsDepth.Load()))
 		}
 	}
 }
@@ -260,7 +265,8 @@ func (a *agent) processorLoop(ctx context.Context, pds <-chan *api.ProbingDirect
 			if !ok {
 				return nil
 			}
-			a.metrics.ChannelDepth.WithLabelValues("pds").Set(float64(len(pds)))
+			a.pdsDepth.Add(-1)
+			a.metrics.ChannelDepth.WithLabelValues("pds").Set(float64(a.pdsDepth.Load()))
 			a.metrics.PDGoroutines.Inc()
 			wg.Add(1)
 			go func() {
@@ -283,7 +289,8 @@ func (a *agent) writerLoop(ctx context.Context, conn net.Conn, fies <-chan *api.
 				return nil
 			}
 
-			a.metrics.ChannelDepth.WithLabelValues("fies").Set(float64(len(fies)))
+			a.fiesDepth.Add(-1)
+			a.metrics.ChannelDepth.WithLabelValues("fies").Set(float64(a.fiesDepth.Load()))
 
 			if err := conn.SetWriteDeadline(time.Now().Add(a.config.WriteDeadline)); err != nil {
 				return fmt.Errorf("failed to set write deadline: %w", err)
@@ -359,6 +366,8 @@ func (a *agent) processPD(ctx context.Context, pd *api.ProbingDirective, fies ch
 
 	select {
 	case fies <- a.buildFIE(pd, nearRes.result, farRes.result, nearTTL, farTTL):
+		a.fiesDepth.Add(1)
+		a.metrics.ChannelDepth.WithLabelValues("fies").Set(float64(a.fiesDepth.Load()))
 	case <-ctx.Done():
 	}
 }


### PR DESCRIPTION
## Summary

Two improvements to the agent pipeline identified during a production
readiness review.

## Changes

### fix: replace racy len(ch) with atomic depth counter for channel metrics

`ChannelDepth` gauge was updated by calling `len(ch)` after a channel
send or receive had already completed. This created a logical race where
the scheduler could allow the consumer goroutine to drain the item before
`len()` was called, causing the gauge to read 0 immediately after a
non-empty send. The metric was consistently understated and unreliable
for backpressure visibility.

Replaced all `len(pds)` and `len(fies)` calls with two `atomic.Int64`
counters (`pdsDepth`, `fiesDepth`) on the agent struct. The counter is
incremented after every successful send and decremented after every
successful receive, with the gauge updated via `Load()` immediately after.

### refactor: replace manual wg.Add/go/Done with wg.Go in processorLoop

Simplified goroutine spawning in `processorLoop` by using `wg.Go()`
instead of the manual `wg.Add(1)` / `go func()` / `defer wg.Done()`
pattern. No behaviour change.

## Testing

Existing test suite passes. The atomic counter correctness is guaranteed
structurally — every send/receive pair is symmetric so the counter cannot
drift over time.