### PR TITLE
chore(gitignore): ignore retina-agent binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+retina-agent


### PR DESCRIPTION
Add retina-agent to .gitignore to prevent committing the built agent binary.