### PR TITLE
refactor(agent): scope probeResult to processPD

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -48,11 +48,6 @@ type agent struct {
 	metrics *Metrics
 }
 
-type probeResult struct {
-	result *ProbeResult
-	err    error
-}
-
 // Run starts the agent and blocks until the context is cancelled or an error occurs.
 func Run(ctx context.Context, cfg *Config, logger *slog.Logger, metrics *Metrics) error {
 	if cfg == nil {
@@ -310,6 +305,11 @@ func (a *agent) writerLoop(ctx context.Context, conn net.Conn, fies <-chan *api.
 // Timed-out probes produce a nil NearInfo or FarInfo in the FIE.
 func (a *agent) processPD(ctx context.Context, pd *api.ProbingDirective, fies chan<- *api.ForwardingInfoElement) {
 	defer a.metrics.PDGoroutines.Dec()
+
+	type probeResult struct {
+		result *ProbeResult
+		err    error
+	}
 
 	nearTTL := pd.NearTTL
 	farTTL := pd.NearTTL + 1


### PR DESCRIPTION
Move probeResult type definition inside processPD to limit its scope.

The type is only used within this function, so keeping it local improves readability and avoids polluting the package-level namespace.