### PR TITLE
refactor: make duplicate in-flight probe detection explicit via ErrDuplicatePD sentinel

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -328,6 +328,9 @@ func (a *agent) processPD(ctx context.Context, pd *api.ProbingDirective, fies ch
 	farRes := <-farCh
 
 	if nearRes.err != nil {
+		if errors.Is(nearRes.err, ErrDuplicatePD) {
+			return // probe already in-flight for this destination/TTL/second
+		}
 		a.logger.Error("Near probe failed",
 			slog.Uint64("pd_id", pd.ProbingDirectiveID),
 			slog.String("dest", pd.DestinationAddress.String()),
@@ -336,12 +339,12 @@ func (a *agent) processPD(ctx context.Context, pd *api.ProbingDirective, fies ch
 		a.metrics.ProbesTotal.WithLabelValues("error").Inc()
 		return
 	}
-	if nearRes.result == nil {
-		return // probe already in-flight for this destination/TTL/second
-	}
 	a.recordProbeOutcome(nearRes.result)
 
 	if farRes.err != nil {
+		if errors.Is(farRes.err, ErrDuplicatePD) {
+			return // probe already in-flight for this destination/TTL/second
+		}
 		a.logger.Error("Far probe failed",
 			slog.Uint64("pd_id", pd.ProbingDirectiveID),
 			slog.String("dest", pd.DestinationAddress.String()),
@@ -349,9 +352,6 @@ func (a *agent) processPD(ctx context.Context, pd *api.ProbingDirective, fies ch
 			slog.Any("err", farRes.err))
 		a.metrics.ProbesTotal.WithLabelValues("error").Inc()
 		return
-	}
-	if farRes.result == nil {
-		return // probe already in-flight for this destination/TTL/second
 	}
 	a.recordProbeOutcome(farRes.result)
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1303,7 +1303,7 @@ func TestProcessPD_NilNearResult(t *testing.T) {
 		prober: &stubProber{
 			probeFunc: func(ctx context.Context, pd *api.ProbingDirective, ttl uint8) (*ProbeResult, error) {
 				if ttl == 5 {
-					return nil, nil // probe already in-flight
+					return nil, ErrDuplicatePD // probe already in-flight
 				}
 				return &ProbeResult{ReplyAddress: net.ParseIP("1.1.1.1")}, nil
 			},
@@ -1332,7 +1332,7 @@ func TestProcessPD_NilFarResult(t *testing.T) {
 		prober: &stubProber{
 			probeFunc: func(ctx context.Context, pd *api.ProbingDirective, ttl uint8) (*ProbeResult, error) {
 				if ttl == 6 {
-					return nil, nil // probe already in-flight
+					return nil, ErrDuplicatePD // probe already in-flight
 				}
 				return &ProbeResult{ReplyAddress: net.ParseIP("1.1.1.1")}, nil
 			},

--- a/internal/agent/caracal_prober.go
+++ b/internal/agent/caracal_prober.go
@@ -235,7 +235,7 @@ func (p *caracalProber) Probe(ctx context.Context, pd *api.ProbingDirective, ttl
 			slog.String("dest", pd.DestinationAddress.String()),
 			slog.Int("ttl", int(ttl)))
 		p.metrics.DuplicateProbesTotal.Inc()
-		return nil, nil
+		return nil, ErrDuplicatePD
 	}
 	p.inFlight[key] = &inFlightProbe{resultCh: resultCh, queuedTime: now}
 	p.metrics.InFlightProbes.Inc()

--- a/internal/agent/caracal_prober_test.go
+++ b/internal/agent/caracal_prober_test.go
@@ -784,8 +784,8 @@ func TestDuplicateProbe(t *testing.T) {
 	defer cancel()
 
 	result, err := prober.Probe(ctx, pd, 64)
-	if err != nil {
-		t.Errorf("duplicate probe should return nil error, got: %v", err)
+	if !errors.Is(err, ErrDuplicatePD) {
+		t.Errorf("duplicate probe should return ErrDuplicatePD, got: %v", err)
 	}
 	if result != nil {
 		t.Errorf("duplicate probe should return nil result, got: %v", result)

--- a/internal/agent/prober.go
+++ b/internal/agent/prober.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -12,12 +13,19 @@ import (
 	"github.com/dioptra-io/retina-commons/api/v1"
 )
 
+var ErrDuplicatePD = errors.New("probing directive is already in-flight")
+
 // Prober sends network probes and returns timing information.
 // Implementations must be safe for concurrent use.
 type Prober interface {
-	// Probe blocks until a reply is received or the probe times out.
-	// TimedOut=true in the result is not an error — only ctx cancellation
-	// or probe operation failures return a non-nil error.
+	// Probe sends a network probe and blocks until one of:
+	//   - a reply is received: returns (result with TimedOut=false, nil)
+	//   - the implementation's internal timeout fires: returns (result with TimedOut=true, nil)
+	//   - a duplicate probe is already in-flight: returns (nil, ErrDuplicateProbe)
+	//   - ctx is cancelled or a probe operation failure occurs: returns (nil, non-nil error)
+	//
+	// Implementations are responsible for enforcing their own probe timeout.
+	// Probe must not block indefinitely — callers do not add a deadline to ctx.
 	Probe(ctx context.Context, pd *api.ProbingDirective, ttl uint8) (*ProbeResult, error)
 
 	// Close releases resources. Safe to call multiple times.


### PR DESCRIPTION
## Problem

The `Prober` interface had a hidden third return state: `(nil, nil)` was used to signal that an identical probe was already in-flight. This violates the standard Go convention that a nil error implies a valid result, making the interface surprising for both callers and future implementors.

## Changes

- Add `ErrDuplicatePD` sentinel error in `prober.go`
- Update `CaracalProber.Probe()` to return `ErrDuplicatePD` instead of `nil, nil`
- Update `processPD` in `agent.go` to handle `ErrDuplicatePD` via `errors.Is`
- Strengthen `Prober` interface documentation to explicitly describe all four return states and the timeout ownership contract
- Update affected tests to reflect the new contract

## Why

The `nil, nil` pattern was a footgun for anyone adding a new `Prober` implementation — a documented extension point in the README. With the sentinel error, the full contract is visible at the interface level and callers handle duplicate detection idiomatically.