### PR TITLE
chore: align agent Dockerfile label with orchestrator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 GOOS=linux \
 
 FROM docker.io/library/debian:bookworm-slim
 
-LABEL maintainer="Elena Nardi <elena.nardi@lip6.fr>"
+LABEL org.opencontainers.image.authors="Dioptra <contact@dioptra.io>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Changes

- Replace `LABEL maintainer` with `LABEL org.opencontainers.image.authors`
  to match the OCI image spec and be consistent with the orchestrator Dockerfile