### PR TITLE
fix(agent): enable TCP keepalives on orchestrator connection

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -42,6 +42,12 @@ import (
 
 var ErrInvalidDirective = errors.New("invalid probing directive")
 
+// orchestratorKeepalivePeriod is the interval between TCP keepalive probes
+// for the orchestrator connection. Keepalives ensure that a dead connection is
+// detected even when no data is being exchanged, triggering reconnection instead
+// of blocking indefinitely on a read timeout.
+const orchestratorKeepalivePeriod = 10 * time.Second
+
 type agent struct {
 	config  *Config
 	prober  Prober
@@ -75,15 +81,23 @@ func Run(ctx context.Context, cfg *Config, logger *slog.Logger, metrics *Metrics
 		metrics: metrics,
 	}
 
-	conn, err := net.Dial("tcp", a.config.OrchestratorAddr)
+	tcpConn, err := net.Dial("tcp", a.config.OrchestratorAddr)
 	if err != nil {
 		return fmt.Errorf("failed to connect to orchestrator: %w", err)
 	}
+	conn := tcpConn.(*net.TCPConn)
 	defer func() {
 		if err := conn.Close(); err != nil {
 			a.logger.Debug("Failed to close connection", slog.Any("err", err))
 		}
 	}()
+
+	if err := conn.SetKeepAlive(true); err != nil {
+		return fmt.Errorf("failed to enable keepalive: %w", err)
+	}
+	if err := conn.SetKeepAlivePeriod(orchestratorKeepalivePeriod); err != nil {
+		return fmt.Errorf("failed to set keepalive period: %w", err)
+	}
 
 	a.logger.Info("Connected to orchestrator",
 		slog.String("address", a.config.OrchestratorAddr))

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -5,9 +5,11 @@
 //
 // Intentionally uncovered (94-95% overall):
 //
-//   - Run (94.3%): defer conn.Close() and defer prober.Close() error paths are
+//   - Run (85%): defer conn.Close() and defer prober.Close() error paths are
 //     unreachable in practice; Go returns nil on Close() of a cleanly established
 //     connection.
+//     SetKeepAlive and SetKeepAlivePeriod error paths are untested; setsockopt
+//     failures are not realistically injectable without low-level OS mocking.
 //
 //   - readerLoop (95.0%): the context cancellation branch inside the select is
 //     timing-dependent and is indirectly covered by TestReaderLoop_ContextCancelled.


### PR DESCRIPTION
## Problem

When the orchestrator connection dies mid-session, the agent's `readerLoop`
detects it only via read timeouts, which are retried indefinitely. The agent
never reconnects, continues probing, and produces no FIEs.

## Fix

Enable TCP keepalives on the orchestrator connection immediately after `Dial`.
When the OS detects a dead connection via keepalive probes, the next read
returns a network error instead of a timeout, which triggers reconnection via
`runWithReconnect`.

## Coverage

`SetKeepAlive` and `SetKeepAlivePeriod` error paths are documented as untested
in `agent_test.go`; `setsockopt` failures are not realistically injectable
without low-level OS mocking.

## Testing

Deployed. Full validation pending.