### PR TITLE
test(agent): replace TestHandleDecodeError_Timeout with TestReaderLoo…

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -48,6 +48,13 @@ var ErrInvalidDirective = errors.New("invalid probing directive")
 // of blocking indefinitely on a read timeout.
 const orchestratorKeepalivePeriod = 10 * time.Second
 
+// maxConsecutiveReadTimeouts is the number of consecutive read timeouts before
+// the connection is considered dead and reconnection is triggered. With the
+// default ReadDeadline of 10s, a dead connection is detected in ~60s. Kept as
+// a constant rather than a config field since operators should tune ReadDeadline
+// instead.
+const maxConsecutiveReadTimeouts = 6
+
 type agent struct {
 	config  *Config
 	prober  Prober
@@ -170,12 +177,14 @@ func (a *agent) authenticate(conn net.Conn) error {
 
 // readerLoop receives and validates ProbingDirective messages from the orchestrator.
 // After MaxConsecutiveDecodeErrors consecutive JSON failures the connection is
-// terminated (set to 0 to disable). Closing pds on return signals processorLoop
-// to drain in-flight goroutines and exit.
+// terminated (set to 0 to disable). After maxConsecutiveReadTimeouts consecutive
+// read timeouts the connection is considered dead and reconnection is triggered.
+// Closing pds on return signals processorLoop to drain in-flight goroutines and exit.
 func (a *agent) readerLoop(ctx context.Context, conn net.Conn, pds chan<- *api.ProbingDirective) error {
 	defer close(pds)
 	decoder := json.NewDecoder(conn)
 	consecutiveDecodeErrors := 0
+	consecutiveTimeouts := 0
 
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(a.config.ReadDeadline)); err != nil {
@@ -184,6 +193,20 @@ func (a *agent) readerLoop(ctx context.Context, conn net.Conn, pds chan<- *api.P
 
 		var pd api.ProbingDirective
 		if err := decoder.Decode(&pd); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				consecutiveTimeouts++
+				a.logger.Debug("Read timeout, no data received",
+					slog.Int("consecutive", consecutiveTimeouts),
+					slog.Int("max", maxConsecutiveReadTimeouts))
+				if consecutiveTimeouts >= maxConsecutiveReadTimeouts {
+					return fmt.Errorf("connection timed out after %d consecutive read timeouts", consecutiveTimeouts)
+				}
+				continue
+			}
+			consecutiveTimeouts = 0
 			shouldContinue, newCount, handledErr := a.handleDecodeError(ctx, err, consecutiveDecodeErrors)
 			consecutiveDecodeErrors = newCount
 			if !shouldContinue {
@@ -193,6 +216,7 @@ func (a *agent) readerLoop(ctx context.Context, conn net.Conn, pds chan<- *api.P
 		}
 
 		consecutiveDecodeErrors = 0
+		consecutiveTimeouts = 0
 		a.metrics.PDsReceivedTotal.Inc()
 
 		if err := validatePD(&pd); err != nil {
@@ -217,17 +241,11 @@ func (a *agent) readerLoop(ctx context.Context, conn net.Conn, pds chan<- *api.P
 }
 
 // handleDecodeError classifies a JSON decode error and decides whether to retry.
-// Returns (shouldContinue, updatedErrorCount, errorToReturn).
+// Timeouts are handled by the caller. Returns (shouldContinue, updatedErrorCount, errorToReturn).
 func (a *agent) handleDecodeError(ctx context.Context, err error, consecutiveErrors int) (bool, int, error) {
 	// Check for context cancellation first, regardless of error type.
 	if ctx.Err() != nil {
 		return false, consecutiveErrors, ctx.Err()
-	}
-
-	// Check for read timeout (expected, just retry).
-	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		a.logger.Debug("Read timeout, no data received")
-		return true, consecutiveErrors, nil
 	}
 
 	// Check for network errors (trigger reconnection)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -11,7 +11,7 @@
 //     SetKeepAlive and SetKeepAlivePeriod error paths are untested; setsockopt
 //     failures are not realistically injectable without low-level OS mocking.
 //
-//   - readerLoop (95.0%): the context cancellation branch inside the select is
+//   - readerLoop (97.0%): the context cancellation branch inside the select is
 //     timing-dependent and is indirectly covered by TestReaderLoop_ContextCancelled.
 //
 //   - caracal_prober.go is excluded entirely; NewCaracalProber requires the caracal
@@ -478,29 +478,6 @@ func TestRun_WithMockConnection(t *testing.T) {
 
 // -- handleDecodeError() ------------------------------------------------------
 
-func TestHandleDecodeError_Timeout(t *testing.T) {
-	t.Parallel()
-
-	a := &agent{
-		config:  &Config{AgentID: "test-agent"},
-		logger:  testLogger(),
-		metrics: testMetrics(),
-	}
-
-	err := &mockNetError{timeout: true, err: "timeout"}
-	shouldContinue, newCount, handledErr := a.handleDecodeError(context.Background(), err, 0)
-
-	if !shouldContinue {
-		t.Error("should continue on timeout")
-	}
-	if newCount != 0 {
-		t.Errorf("error count should remain 0, got: %d", newCount)
-	}
-	if handledErr != nil {
-		t.Errorf("should not return error on timeout, got: %v", handledErr)
-	}
-}
-
 func TestHandleDecodeError_ContextCancelled(t *testing.T) {
 	t.Parallel()
 
@@ -777,6 +754,33 @@ func TestReaderLoop_ConsecutiveDecodeErrors(t *testing.T) {
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("readerLoop did not exit after consecutive decode errors")
+	}
+}
+
+func TestReaderLoop_DeadConnectionDetection(t *testing.T) {
+	t.Parallel()
+
+	a := &agent{
+		config: &Config{
+			AgentID:      "test-agent",
+			ReadDeadline: 1 * time.Millisecond,
+		},
+		logger:  testLogger(),
+		metrics: testMetrics(),
+	}
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	pds := make(chan *api.ProbingDirective, 1)
+	err := a.readerLoop(context.Background(), client, pds)
+
+	if err == nil {
+		t.Fatal("expected error after consecutive timeouts, got nil")
+	}
+	if !strings.Contains(err.Error(), "connection timed out after") {
+		t.Errorf("expected timeout error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

TCP keepalives alone cannot detect a dead connection within a reasonable
time due to untunable kernel defaults for `TCP_KEEPINTVL` and
`TCP_KEEPCNT`. With the system defaults (75s interval, 9 probes), detection
could take up to ~685s. During this time, `readerLoop` retries read timeouts
indefinitely, the agent never reconnects, and the orchestrator queue fills up
and never drains.

## Fix

Track consecutive read timeouts separately from JSON decode errors in
`readerLoop`. After `maxConsecutiveReadTimeouts` (6) consecutive timeouts,
the connection is considered dead and an error is returned, triggering
reconnection via `runWithReconnect`. With the default `ReadDeadline` of 10s,
a dead connection is detected in ~60s.

Timeout handling is removed from `handleDecodeError`, which now covers JSON
decode errors only.

`maxConsecutiveReadTimeouts` is a package-level constant rather than a config
field — operators should tune `ReadDeadline` instead.

## Testing

`TestHandleDecodeError_Timeout` replaced by
`TestReaderLoop_DeadConnectionDetection`, which uses a `net.Pipe()` connection
that never sends data to verify that `readerLoop` returns the expected error
after 6 consecutive timeouts. Coverage increases from 95.0% to 97.0%.

Deployed to me-central. Full validation pending.