### PR TITLE
chore: enforce commit validation and CI standards

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+COMMIT_MSG_FILE=$1
+
+if ! grep -q "^Signed-off-by:" "$COMMIT_MSG_FILE"; then
+  echo "❌ Error: Missing 'Signed-off-by:' signature."
+  echo "💡 Tip: Use 'git commit -s' to add it automatically."
+  exit 1
+fi
+
+HEADER_LINE=$(head -n 1 "$COMMIT_MSG_FILE")
+
+if [ "${#HEADER_LINE}" -gt 72 ]; then
+  echo "❌ Error: Commit subject is too long (${#HEADER_LINE} chars). Max: 72."
+  exit 1
+fi
+
+# Allowed types: feat, fix, refactor, test, docs, deps, chore, perf
+PATTERN="^(feat|fix|refactor|test|docs|deps|chore|perf)(\([^)]+\))?: .+"
+
+if ! [[ "$HEADER_LINE" =~ $PATTERN ]]; then
+  echo "❌ Error: Invalid commit format."
+  echo "Expected format: <type>: <subject in imperative mood>"
+  echo "Allowed types: feat, fix, refactor, test, docs, deps, chore, perf"
+  echo "Example: feat: add ICMP echo probe support"
+  exit 1
+fi
+
+echo "✅ Commit format validated locally."

--- a/.github/workflows/commitlint-pr.yml
+++ b/.github/workflows/commitlint-pr.yml
@@ -1,0 +1,32 @@
+name: Validate Commit Messages
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  commit-validation:
+    name: Enforce Commit Format & Sign-off
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate PR Commits using local hook
+        run: |
+          chmod +x .githooks/commit-msg
+          
+          COMMITS=$(git rev-list origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }})
+          
+          for COMMIT in $COMMITS; do
+            echo "Checking commit $COMMIT..."
+            git log --format=%B -n 1 $COMMIT > /tmp/commit_msg.txt
+            
+            ./.githooks/commit-msg /tmp/commit_msg.txt || {
+              echo "❌ Please fix the above error(s) using 'git rebase -i' and force push."
+              exit 1
+            }
+          done
+          echo "✅ All commits comply with the rules."

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
-.PHONY: build lint fmt tidy test run clean help
+.PHONY: build lint fmt tidy test cover run clean setup-hooks help
 
 help:
 	@echo "Valid targets:"
-	@echo "  build  - Format, lint, and build retina-agent binary"
-	@echo "  lint   - Format code and run linters"
-	@echo "  fmt    - Format code"
-	@echo "  tidy   - Tidy go modules"
-	@echo "  test   - Run tests with race detection"
-	@echo "  run    - Build and run retina-agent"
-	@echo "  clean  - Remove built binaries"
+	@echo "  build       - Format, lint, and build retina-agent binary"
+	@echo "  lint        - Format code and run linters"
+	@echo "  fmt         - Format code"
+	@echo "  tidy        - Tidy go modules"
+	@echo "  test        - Run tests with race detection and generate coverage profile"
+	@echo "  cover       - View test coverage in browser"
+	@echo "  run         - Build and run retina-agent"
+	@echo "  clean       - Remove built binaries and coverage files"
+	@echo "  setup-hooks - Configure local Git hooks for commit validation"
 
 build: lint
 	go build -o retina-agent ./cmd/retina-agent
@@ -23,10 +25,18 @@ tidy:
 	go mod tidy
 
 test:
-	go test -v -race -cover ./...
+	go test -v -race -coverprofile=coverage.out ./...
+
+cover:
+	go tool cover -html=coverage.out
 
 run: build
 	./retina-agent
 
 clean:
-	rm -f retina-agent
+	rm -f retina-agent coverage.out
+
+setup-hooks:
+	@mkdir -p .githooks
+	@git config core.hooksPath .githooks
+	@echo "✅ Local Git hooks configured successfully!"


### PR DESCRIPTION
## What
Added local Git hooks and a GitHub Actions workflow to strictly enforce Conventional Commits and the `Signed-off-by` trailer.

## Why
To fully comply with the new Retina Developer's Handbook guidelines before the core system stabilizes, ensuring a clean, linear history and high code quality.

## Testing
- [x] Unit tests added/updated (N/A)
- [x] Integration tests pass (CI checks passed)
- [x] Manual testing (if needed) (Tested local hook triggers correctly)
- [x] Backwards compatibility verified (if applicable)

## Notes
Developers will need to run `make setup-hooks` locally after pulling this branch to activate the pre-commit validation.